### PR TITLE
[FIX] fix backslash issue in links

### DIFF
--- a/ar1_processes-MyST.md
+++ b/ar1_processes-MyST.md
@@ -378,11 +378,11 @@ Test the class you have written by going through the steps
 
 for distributions $\phi$ of the following types
 
--   [beta distribution](https://en.wikipedia.org/wiki/Beta\_distribution\)
+-   [beta distribution](https://en.wikipedia.org/wiki/Beta_distribution)
     with $\alpha = \beta = 2$
--   [beta distribution](https://en.wikipedia.org/wiki/Beta\_distribution\)
+-   [beta distribution](https://en.wikipedia.org/wiki/Beta_distribution)
     with $\alpha = 2$ and $\beta = 5$
--   [beta distribution](https://en.wikipedia.org/wiki/Beta\_distribution\)
+-   [beta distribution](https://en.wikipedia.org/wiki/Beta_distribution)
     with $\alpha = \beta = 0.5$
 
 Use $n=500$.


### PR DESCRIPTION
I suspect this came from `pandoc` converter. 

There are cases where backslash special characters is incorrect. 